### PR TITLE
Avoid panic on broken pipe

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use rand::thread_rng;
 use rand::Rng;
 
@@ -34,5 +36,5 @@ fn main() {
     let mut rng = thread_rng();
     let rule_index = rng.gen_range(0..rules.len());
 
-    println!("{}. {}", rule_index + 1, rules[rule_index]);
+    let _ = writeln!(std::io::stdout(), "{}. {}", rule_index + 1, rules[rule_index]);
 }


### PR DESCRIPTION
The standard lib ignores `SIGPIPE`, so writing to a closed `stdout` results in `write` returning `EPIPE`. Since `println!` implicitly unwraps, the program panics on a broken pipe. Ignoring the error seems more appropriate here, so the user can focus on the real problem (like a missing `cowsay`).